### PR TITLE
[FIX] website_sale_comparison: Ensure product_data available

### DIFF
--- a/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
@@ -189,8 +189,12 @@ var ProductComparison = publicWidget.Widget.extend(VariantMixin, {
         var self = this;
         this.$('.o_comparelist_products .o_product_row').remove();
         _.each(this.comparelist_product_ids, function (res) {
-            var $template = self.product_data[res].render;
-            self.$('.o_comparelist_products').append($template);
+            if (self.product_data.hasOwnProperty(res)) {
+                // It is possible that we do not have the required product_data for all IDs in
+                // comparelist_product_ids
+                var $template = self.product_data[res].render;
+                self.$('.o_comparelist_products').append($template);
+            }
         });
         if (force !== 'hide' && (this.comparelist_product_ids.length > 1 || force === 'show')) {
             $('#comparelist .o_product_panel_header').popover('show');


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install "website_sale_comparison"
    2. Go to an e-commerce website
    3. Open 2 different products on separate tabs
    4. Click compare on 1 of the product tabs
    5. Switch to the other product tab and click compare

What is currently happening ?

    There is a JavaScript error.

What are you expecting to happen ?

    Both products to be added to the comparison panel.

Why is this happening ?

    Because the product ID from the first tab was never loaded into the comparison table before adding the second product.
    The user is required to first refresh the page or navigate to the second product after adding the first.

How to fix the bug ?

    Check whether the product ID of the first item exists inside product_data before trying to access it.
    Although it means the first item still does not appear, both products will be present in the user's cookies.
    When the user refreshes the page or navigates away, both products will be visible in the comparison panel.